### PR TITLE
Bugfix/bill token false

### DIFF
--- a/lib/pxfusion/transaction.rb
+++ b/lib/pxfusion/transaction.rb
@@ -102,8 +102,7 @@ class PxFusion::Transaction < OpenStruct
         # THE ORDER MATTERS
         attributes = transaction.instance_variable_get("@table")
 
-        return get_transaction_id_with_token(transaction) if attributes[:token_billing]
-        get_transaction_id_without_token(transaction)
+        attributes[:token_billing] ? get_transaction_id_with_token(transaction) : get_transaction_id_without_token(transaction)
       end
     end
 end


### PR DESCRIPTION
@joshmcarthur This pull request adds two new methods: `get_transaction_id_with_token` and `get_transaction_id_without_token`.

These methods can be called independently, or can be delegated to by calling `get_transaction_id`. This method will choose which method to use for requesting the transaction id from PxFusion. If you call this method with `token_billing: true` in the params, it will call the `get_transaction_id_with_token` method, other wise it will get the transaction id, without returning a token.

This fixed a bug for me on Consumer NZ.

Please have a good look at this as Im sure it could be cleaned up, or changed back to one method. I took this approach because the order of the params entered into the soap request seems to be so important (it was the easy way).
